### PR TITLE
Prealpha Build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyNaCl~=1.5.0
 python-dotenv~=1.0.0
 git+https://github.com/ytdl-org/youtube-dl.git@master#egg=youtube_dl
 flask~=3.0.0
+async-timeout~=4.0.3

--- a/src/console.py
+++ b/src/console.py
@@ -144,6 +144,9 @@ class Console:
                 _log.warning(
                     "Command %s Usage Error: '%s'.", command[0].upper(), e.args[0]
                 )
+            except EOFError:
+                _log.warning("No console input detected. Shutting down console.")
+                self.online = False
 
 
 def __build_console_commands(console: Console, client: MusicClient):

--- a/src/main.py
+++ b/src/main.py
@@ -67,7 +67,7 @@ def run(token: str, hostname, port: int):
             client.start(token=token, reconnect=True),
             console.start(get_console_input),
             web_console.start(),
-            API.start(HOSTNAME, API_PORT),
+            # API.start(HOSTNAME, API_PORT),    # Disabled for prealpha
         )
 
     try:


### PR DESCRIPTION
Prepared repo for prealpha build and release.

- fix: `requirements.txt` missing `async_timeout`.
- fix: `console` gracefully exits on EOFError (occurs during non-interactive sessions i.e. containers)
- disabled Flask for the prealpha release.